### PR TITLE
Simplified interface

### DIFF
--- a/location-scrubber/index.html
+++ b/location-scrubber/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css">
+
 <head>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
@@ -41,12 +43,11 @@
         }
 
         .button {
-            border-radius: 10px;
             background-color: #4CAF50;
             /* Green */
             border: none;
             color: white;
-            padding: 10px 20px;
+            padding: 20px 40px;
             text-align: center;
             text-decoration: none;
             display: inline-block;
@@ -70,6 +71,62 @@
             padding: 0;
             margin-top: 20px;
         }
+
+        /* Style buttons */
+        .btn {
+            background-color: blue;
+            /* Blue background */
+            border: none;
+            /* Remove borders */
+            color: white;
+            /* White text */
+            padding: 12px 16px;
+            /* Some padding */
+            font-size: 16px;
+            /* Set a font size */
+            cursor: pointer;
+            /* Mouse pointer on hover */
+        }
+
+        /* Darker background on mouse-over */
+        .btn:hover {
+            background-color: darkblue;
+        }
+
+        .btn_delete {
+            background-color: red;
+        }
+
+        .btn_delete:hover {
+            background-color: darkred;
+        }
+
+        .btn_view {
+            background-color: orange;
+        }
+
+        .btn_view:hover {
+            background-color: darkorange;
+        }
+
+        .disabled {
+            background-color: #777;
+        }
+
+        .disabled:hover {
+            background-color: #777;
+        }
+
+
+
+        /* Darker background on mouse-over */
+        .pressed {
+            background-color: #000058;
+        }
+
+        .pressed:hover {
+            background-color: #000058;
+        }
     </style>
 </head>
 
@@ -77,17 +134,37 @@
     <div id="floating-panel">
         <h2>Safe Places - Redaction Tool</h2>
 
-        <input id="privatekitJSON" style="display:none;" type="file" onchange="loadPath()" />
+        <input id="privatekitJSON" style="display:none;" type="file" accept=".json,.null" onchange="loadPath()" />
 
-        <input class="button" type="button" id="loadFileXml" value="Load"
-            onclick="$('#privatekitJSON').click();" />
+        <input class="button" type="button" id="loadFileXml" value="Load" onclick="$('#privatekitJSON').click();" />
         <input id="save" class="button disabled" disabled="disabled" onclick="saveText();" type=button value="Save" />
         <hr />
         <div>
-            <div>Erase Point: <input type="checkbox" id="eraser-point" value="true" /></div>
-            <div><input onclick="selectArea();" type="button" id="eraser-area" value="Select Area" /></div>
-            <div><input type="button" id="zoomToExtent" class="button" onclick="zoomToExtent()" value="Zoom to Extents" /></div>
-            <div>Classify Points<input type="checkbox" id="classify"  onchange="toggleClassification()" value="Classify Points" /></div>
+            <button class="btn" onclick="selectNone()" id="select-point">
+                <i class="fas fa-hand-pointer"></i> Select Point</button>
+            <button class="btn" onclick="selectArea();" id="select-area">
+                <i class="fa fa-object-group"></i> Select Area</button>
+            <button class="btn" onclick="selectNone();" id="select-none">
+                <i class="fa fa-ban"></i> Select None</button>&nbsp;
+
+            <p />
+
+            <button class="btn btn_delete disabled" onclick="deleteAll()" id="delete-all-btn">
+                <i class="fa fa-trash-alt"></i> Delete All</button>
+            <button class="btn btn_delete disabled" onclick="deleteSelectedMarker()" id="delete-btn">
+                <i class="fa fa-trash-alt"></i> Delete</button>
+            <button class="btn btn_view" onclick="zoomToExtent()" id="zoomToExtent">
+                <i class="fas fa-expand-arrows-alt"></i> Zoom</button>
+
+            <!-- No more "erase mode", use Delete button after picking
+                <div>Erase Point: <input type="checkbox" id="eraser-point" value="true" /></div>
+            -->
+
+            <!-- Classify all the time
+                
+                div>Classify Points<input type="checkbox" id="classify" onchange="toggleClassification()"
+                    value="Classify Points" /></div>
+            -->
         </div>
     </div>
     <div id="map"></div>
@@ -105,14 +182,16 @@
 
         var MAP_API_KEY = localStorage.getItem("MAP_API_KEY")
 
-        if (!IsValid(MAP_API_KEY) || MAP_API_KEY == "")
+        if (!IsValid(MAP_API_KEY) || MAP_API_KEY == "" || MAP_API_KEY == null || MAP_API_KEY == "null" || MAP_API_KEY ==
+            "MAP_API_KEY")
             enterAPIKey();
         else {
             var script = document.createElement("script");
             script.async = true;
             script.defer = true;
             script.src =
-                "https://maps.googleapis.com/maps/api/js?key=" + MAP_API_KEY + "&libraries=drawing,geometry&callback=initMap";
+                "https://maps.googleapis.com/maps/api/js?key=" + MAP_API_KEY +
+                "&libraries=drawing,geometry&callback=initMap";
             document.head.appendChild(script);
 
 
@@ -128,7 +207,7 @@
 
         function enterAPIKey() {
             MAP_API_KEY = prompt(
-                "Enter a Google Maps JavaScript API Key (this is stored in your browser only and avoids Github API throttles):",
+                "Enter a Google Maps JavaScript API Key.  You can obtain this from you support team.:",
                 "MAP_API_KEY");
             localStorage.setItem('MAP_API_KEY', MAP_API_KEY);
             location.reload();
@@ -136,8 +215,14 @@
 
         var exposurePoints;
         var exposurePaths;
-        var exposureGroups; //associated array of groupId to markers, JSON elements, and LatLngBounds objects contained within each group
-        const GROUP_TYPES = {UNDEF: "undefined", RECURRING: "recurring", TRANSIENT: "transient", TRAVEL: "travel"};
+        var
+            exposureGroups; //associated array of groupId to markers, JSON elements, and LatLngBounds objects contained within each group
+        const GROUP_TYPES = {
+            UNDEF: "undefined",
+            RECURRING: "recurring",
+            TRANSIENT: "transient",
+            TRAVEL: "travel"
+        };
         var exposureJSON;
 
         const MARKER_ICONS = {
@@ -147,13 +232,15 @@
             RECURRING: 'http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|e661ac', //PINK
             TRANSIENT: 'http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|ff9900', //ORANGE
             TRAVEL: 'http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|fdf569' //YELLOW
-            }
+        }
         var map;
         var infoWindow;
         var drawingManager;
         var selectedArea;
         var selectedAreaControls;
         var selectedMarker;
+        var global_uncolorClosure = null;
+        var selectedGroupID = null;
         var fileRegExp = new RegExp(/\.json$/);
 
         function initMap() {
@@ -168,8 +255,8 @@
 
             infoWindow = new google.maps.InfoWindow();
 
-            google.maps.event.addListenerOnce(map, 'bounds_changed', function(event) {
-                this.setZoom(map.getZoom()-1);
+            google.maps.event.addListenerOnce(map, 'bounds_changed', function (event) {
+                this.setZoom(map.getZoom() - 1);
 
                 if (this.getZoom() > 15) {
                     this.setZoom(15);
@@ -188,6 +275,7 @@
                 drawingManager.setDrawingMode(null);
                 selectedArea = rectangle;
 
+                /* SSP: Removing infowindow
                 let infoWindow = new google.maps.InfoWindow();
                 selectedAreaControls = infoWindow;
 
@@ -198,44 +286,65 @@
                 latLng.lat = rectangle.getBounds().getNorthEast().lat;
                 infoWindow.setPosition(latLng);
                 infoWindow.open(map);
+                */
 
                 google.maps.event.addListener(rectangle, 'mouseover', (function (rectangle, infoWindow) {
                     return function (event) {
-                        infoWindow.close();
+                        //x infoWindow.close();
                         let latLng = rectangle.getBounds().getCenter();
                         latLng.lat = rectangle.getBounds().getNorthEast().lat;
-                        infoWindow.setPosition(latLng);
-                        infoWindow.setPosition(latLng);
-                        infoWindow.open(map);
+                        //x infoWindow.setPosition(latLng);
+                        //x infoWindow.setPosition(latLng);
+                        //x infoWindow.open(map);
                     };
                 })(rectangle, infoWindow));
 
                 google.maps.event.addListener(rectangle, 'drag', (function (rectangle, infoWindow) {
                     return function (event) {
-                        infoWindow.close();
+                        //x infoWindow.close();
                         let latLng = rectangle.getBounds().getCenter();
                         latLng.lat = rectangle.getBounds().getNorthEast().lat;
-                        infoWindow.setPosition(latLng);
-                        infoWindow.setPosition(latLng);
-                        infoWindow.open(map);
+                        //x infoWindow.setPosition(latLng);
+                        //x infoWindow.setPosition(latLng);
+                        //x infoWindow.open(map);
                     };
                 })(rectangle, infoWindow));
 
                 google.maps.event.addListener(rectangle, 'bounds_changed', (function (rectangle, infoWindow) {
                     return function (event) {
-                        infoWindow.close();
+                        //x infoWindow.close();
                         let latLng = rectangle.getBounds().getCenter();
                         latLng.lat = rectangle.getBounds().getNorthEast().lat;
-                        infoWindow.setPosition(latLng);
-                        infoWindow.setPosition(latLng);
-                        infoWindow.open(map);
+                        //x infoWindow.setPosition(latLng);
+                        //x infoWindow.setPosition(latLng);
+                        //x infoWindow.open(map);
                     };
                 })(rectangle, infoWindow));
+
+                document.getElementById("select-area").classList.remove("pressed");
+                enableDelete(true, false);
             });
         }
 
-        function selectArea() {
+        function selectNone() {
+            if (global_uncolorClosure) {
+                global_uncolorClosure();
+            }
             deleteAreaBoundary();
+        }
+
+        function selectArea() {
+            if (document.getElementById("select-area").classList.contains("pressed")) {
+                // Already in select area mode, untoggle button and exit the 
+                document.getElementById("select-area").classList.remove("pressed");
+                drawingManager.setDrawingMode(null);
+                return;
+            }
+
+
+            // Erase any existing selection rect and put user in rect drawing mode
+            selectNone();
+            document.getElementById("select-area").classList.add("pressed");
 
             //Setting options for the Drawing Tool. In our case, enabling Polygon shape.
             drawingManager.setOptions({
@@ -256,9 +365,13 @@
             });
         }
 
+        function deleteMarker() {
+            erasePoint();
+        }
+
         function deleteAreaMarkers() {
-            if (selectedArea !== undefined && selectedArea !== null) {
-                if (exposurePoints !== undefined && exposurePoints !== null) {
+            if (IsValid(selectedArea)) {
+                if (IsValid(exposurePoints)) {
                     let areaBounds = selectedArea.getBounds();
                     exposurePoints.forEach(function (element, index) {
                         if (areaBounds.contains(element.getPosition())) {
@@ -271,17 +384,27 @@
         }
 
         function deleteAreaBoundary() {
+            // Remove any selection area
             if (selectedArea !== undefined && selectedArea !== null) {
                 selectedArea.setMap(null);
                 selectedArea = null;
-                selectedAreaControls.close();
-                selectedAreaControls = null;
+
+                if (IsValid(selectedAreaControls)) {
+                    selectedAreaControls.close();
+                    selectedAreaControls = null;
+                }
             }
+
+            enableDelete(false, false);
         }
 
         function clearMap() {
             clearMarkers();
             clearPolylines();
+
+            selectedGroupID = null;
+            selectedMarker = null;
+            global_uncolorClosure = null;
         }
 
         function clearMarkers() {
@@ -295,9 +418,20 @@
             }
         }
 
-        function deleteMarker(marker) {
-            removeMarker(marker);
-            marker = null;
+        function deleteAll() {
+            if (IsValid(selectedArea)) {
+                deleteAreaMarkers();
+            } else {
+                eraseGroup(null, selectedGroupID);
+                global_uncolorClosure();
+            }
+        }
+
+        function deleteSelectedMarker() {
+            if (selectedMarker) {
+                editExposure(0, selectedMarker);
+                selectedGroupID = null;
+            }
         }
 
         function clearPolylines() {
@@ -324,6 +458,22 @@
             }
         }
 
+        function enableDelete(all, single) {
+
+            var btnDeleteAll = document.getElementById("delete-all-btn");
+            var btnDelete = document.getElementById("delete-btn");
+
+            if (all)
+                btnDeleteAll.classList.remove("disabled");
+            else
+                btnDeleteAll.classList.add("disabled");
+
+            if (single)
+                btnDelete.classList.remove("disabled");
+            else
+                btnDelete.classList.add("disabled");
+        }
+
         function loadPath() {
 
             file = $("#privatekitJSON").get(0).files[0];
@@ -348,12 +498,15 @@
                         exposureJSON = JSON.parse(lines);
 
                         exposureJSON.forEach(function (element, index) {
-                            elementLatLng = new google.maps.LatLng(element.latitude, element.longitude);                            
+                            elementLatLng = new google.maps.LatLng(element.latitude, element
+                                .longitude);
 
                             let marker = new google.maps.Marker({
                                 position: elementLatLng,
                                 //label: 'ID:' + element.id,
-                                title: new Date(element.time).toLocaleString(),
+                                title: new Date(Math.trunc(element.time /
+                                    1000)) // convert to UCT unix to a "human" time.  TODO: Local time conversion needed?
+                                    .toLocaleString(),
                                 icon: MARKER_ICONS.DEFAULT,
                                 map: map
                             });
@@ -361,8 +514,9 @@
                             points.push(marker);
 
                             //create a circle with which to measure a 100' radius from the center of our current bounds
-                            if(!currentGroupBounds.isEmpty() && (google.maps.geometry.spherical.computeDistanceBetween(elementLatLng, currentGroupBounds.getCenter()) > 30.48))
-                            {
+                            if (!currentGroupBounds.isEmpty() && (google.maps.geometry.spherical
+                                    .computeDistanceBetween(elementLatLng, currentGroupBounds
+                                        .getCenter()) > 30.48)) {
                                 //save off the previous group for later evaluation as recurring or transient
                                 exposureGroups[currentGroupId].bounds = currentGroupBounds;
 
@@ -376,9 +530,13 @@
                             currentGroupBounds.extend(elementLatLng);
 
                             //create a new object to hold the groups if we don't have one already
-                            if(exposureGroups[currentGroupId] === undefined || exposureGroups[currentGroupId] === null)
-                            {
-                                exposureGroups[currentGroupId] = {markers:[],elements:[],bounds:currentGroupBounds}
+                            if (exposureGroups[currentGroupId] === undefined || exposureGroups[
+                                    currentGroupId] === null) {
+                                exposureGroups[currentGroupId] = {
+                                    markers: [],
+                                    elements: [],
+                                    bounds: currentGroupBounds
+                                }
                             }
                             exposureGroups[currentGroupId].markers.push(marker);
                             exposureGroups[currentGroupId].elements.push(element);
@@ -388,41 +546,75 @@
                             element.groupType = GROUP_TYPES.UNDEF;
 
                             //we add the event listener after we determine what group the marker is in
-                            google.maps.event.addListener(marker, 'click', (function(thisMarker, groupId){
+                            google.maps.event.addListener(marker, 'click', (function (thisMarker,
+                                groupId) {
                                 return function (event) {
                                     /*if ($("#eraser-point").prop("checked")) {
                                         editExposure(event, this);
                                     }*/
-                                    selectedMarker = thisMarker;
-                                    infoWindow.setContent('<input type="button" onclick="erasePoint(event);" value="Erase Selected Point" /><br /><input type="button" onclick="eraseGroup(event, '+  groupId +');" value="Erase Selected Group" />');
-                                    
-                                    //when we click a marker set all the markers in that group to purple
-                                    exposureGroups[groupId].markers.forEach(function(element,index){
-                                        element.setIcon(MARKER_ICONS.GROUP)
-                                    });
+
+                                    /* SSP: Disable infowindow use                                    
+                                    infoWindow.setContent(
+                                        '<input type="button" onclick="erasePoint(event);" value="Erase Selected Point" /><br /><input type="button" onclick="eraseGroup(event, ' +
+                                        groupId +
+                                        ');" value="Erase Selected Group" />');
+                                    */
+
+                                    selectNone();
+                                    enableDelete(false);
+
+                                    // when we click a marker set all the markers in that group to purple
+                                    exposureGroups[groupId].markers.forEach(
+                                        function (element, index) {
+                                            element.setIcon(MARKER_ICONS.GROUP)
+                                        });
                                     //then set the clicked marker to green
                                     thisMarker.setIcon(MARKER_ICONS.SELECTED);
-                                    
-                                    let uncolorColsure = (function(groupId){
-                                        return function(event){
-                                            exposureGroups[groupId].markers.forEach(function(element,index){
-                                                element.setIcon(MARKER_ICONS.DEFAULT)
-                                            });
-                                            zoomToExtent();
+
+                                    let uncolorColsure = (function (groupId) {
+                                        return function (event) {
+                                            exposureGroups[groupId]
+                                                .markers.forEach(
+                                                    function (element,
+                                                        index) {
+                                                        element.setIcon(
+                                                            MARKER_ICONS
+                                                            .DEFAULT
+                                                        )
+                                                    });
+
+                                            // After the load, zoom to see all
+                                            // zoomToExtent();
+                                            //x selectedMarker = null;
+                                            if (groupId ==
+                                                selectedGroupID)
+                                                selectedGroupID = null;
+
+                                            enableDelete(false, false);
                                         }
                                     })(groupId);
 
                                     //when we close the InfoWindow, set all the colored markers back to red
-                                    google.maps.event.addListener(infoWindow, 'closeclick', uncolorColsure);
-                                    google.maps.event.addListener(infoWindow, 'content_changed', uncolorColsure);
+                                    //x google.maps.event.addListener(infoWindow,
+                                    //x     'closeclick', uncolorColsure);
+                                    //x google.maps.event.addListener(infoWindow,
+                                    //x     'content_changed', uncolorColsure);
 
-                                    zoomToExtent(exposureGroups[groupId].bounds);
-                                    infoWindow.open(map,this);
+                                    // zoomToExtent(exposureGroups[groupId].bounds);
+
+                                    //x infoWindow.open(map, this);
+                                    selectedGroupID = groupId;
+                                    selectedMarker = thisMarker;
+                                    global_uncolorClosure = uncolorColsure;
+
+                                    enableDelete(
+                                        exposureGroups[groupId].markers.length >
+                                        1,
+                                        true);
                                 }
                             })(marker, currentGroupId));
 
-                            if(lastLatLng !== undefined && lastLatLng !== null)
-                            {
+                            if (lastLatLng !== undefined && lastLatLng !== null) {
                                 let polylinePath = new google.maps.Polyline({
                                     path: [lastLatLng, elementLatLng],
                                     strokeColor: '#FF0000',
@@ -435,55 +627,59 @@
 
                             lastLatLng = elementLatLng;
                         });
+
+                        // Zoom to see all of the loaded points
                         zoomToExtent();
 
                         let groupCount = 0;
                         let exposureGroupKeys = Object.keys(exposureGroups);
                         let travelGroupId = null;
-                        for(const key of exposureGroupKeys)
-                        {
+                        for (const key of exposureGroupKeys) {
                             groupCount++;
 
                             let foundIntersection = false;
-                            for(var i = groupCount; i < exposureGroups.length; i++)
-                            {
-                                if(exposureGroups[key].bounds.intersects(exposureGroups[exposureGroupKeys[i]].bounds))
-                                {
+                            for (var i = groupCount; i < exposureGroups.length; i++) {
+                                if (exposureGroups[key].bounds.intersects(exposureGroups[exposureGroupKeys[
+                                        i]].bounds)) {
                                     foundInteresection = true;
-                                    exposureGroups[key].elements.forEach(function(element,index){ element.groupType=GROUP_TYPES.RECURRING; });
-                                    exposureGroups[exposureGroupKeys[i]].elements.forEach(function(element,index){ element.groupType=GROUP_TYPES.RECURRING; });
+                                    exposureGroups[key].elements.forEach(function (element, index) {
+                                        element.groupType = GROUP_TYPES.RECURRING;
+                                    });
+                                    exposureGroups[exposureGroupKeys[i]].elements.forEach(function (element,
+                                        index) {
+                                        element.groupType = GROUP_TYPES.RECURRING;
+                                    });
                                 }
                             }
 
                             //we can only be a travel group if we were previously not found to be a recurring group, and we found no intersections with the groups in front of us
-                            if(!foundIntersection && exposureGroups[key].elements[0].groupType != GROUP_TYPES.RECURRING)
-                            {
+                            if (!foundIntersection && exposureGroups[key].elements[0].groupType !=
+                                GROUP_TYPES.RECURRING) {
                                 let travelMaxGroupSize = 3;
-                                if(exposureGroups[key].elements.length <= travelMaxGroupSize)
-                                {
+                                if (exposureGroups[key].elements.length <= travelMaxGroupSize) {
                                     //groupCount is currently pointing to the item in front of the current group identified by key
                                     //  we want to check to see if the previous group (two back from current groupCount value) was a travel group.
                                     //  If so, we set keep the current travelGroupId and use that value.
                                     //  If not, we increment the travelGroupId and take that value instead.
                                     //  but we only look back if we are not the first group
-                                    if(groupCount > 1)
-                                    {
-                                        if(exposureGroups[exposureGroupKeys[groupCount-2]].elements[0].groupType != GROUP_TYPES.TRAVEL)
-                                        {
-                                            if(travelGroupId === undefined || travelGroupId === null){
+                                    if (groupCount > 1) {
+                                        if (exposureGroups[exposureGroupKeys[groupCount - 2]].elements[0]
+                                            .groupType != GROUP_TYPES.TRAVEL) {
+                                            if (travelGroupId === undefined || travelGroupId === null) {
                                                 travelGroupId = 0;
-                                            }
-                                            else
-                                            {
+                                            } else {
                                                 travelGroupId++;
                                             }
                                         }
                                     }
-                                    exposureGroups[key].elements.forEach(function(element,index){ element.groupType=GROUP_TYPES.TRAVEL;  element.travelGroupId=travelGroupId; });
-                                }
-                                else
-                                {
-                                    exposureGroups[key].elements.forEach(function(element,index){ element.groupType=GROUP_TYPES.TRANSIENT; });
+                                    exposureGroups[key].elements.forEach(function (element, index) {
+                                        element.groupType = GROUP_TYPES.TRAVEL;
+                                        element.travelGroupId = travelGroupId;
+                                    });
+                                } else {
+                                    exposureGroups[key].elements.forEach(function (element, index) {
+                                        element.groupType = GROUP_TYPES.TRANSIENT;
+                                    });
                                 }
                             }
                         }
@@ -492,48 +688,74 @@
                 fr.readAsText(file);
 
                 $("#save").removeClass("disabled").addClass("enabled").prop("disabled", false);
+
+                // Auto-classify (no reason not to do this)
+                toggleClassification();
             }
         }
 
-        function toggleClassification(){
-            infoWindow.close();
-            zoomToExtent();
+        function toggleClassification() {
+            //x infoWindow.close();
+            // zoomToExtent();
             let markerIcon = MARKER_ICONS.DEFAULT;
 
             let exposureGroupKeys = Object.keys(exposureGroups);
-            for(const key of exposureGroupKeys)
-            {
-                if($("#classify").prop("checked")){
+            for (const key of exposureGroupKeys) {
+                if ($("#classify").prop("checked")) {
                     let groupType = exposureGroups[key].elements[0].groupType;
-                    if(groupType == GROUP_TYPES.RECURRING)
-                    {
+                    if (groupType == GROUP_TYPES.RECURRING) {
                         markerIcon = MARKER_ICONS.RECURRING;
-                    }
-                    else if(groupType == GROUP_TYPES.TRANSIENT)
-                    {
+                    } else if (groupType == GROUP_TYPES.TRANSIENT) {
                         markerIcon = MARKER_ICONS.TRANSIENT;
-                    }
-                    else if(groupType == GROUP_TYPES.TRAVEL)
-                    {
+                    } else if (groupType == GROUP_TYPES.TRAVEL) {
                         markerIcon = MARKER_ICONS.TRAVEL;
                     }
                 }
-                exposureGroups[key].markers.forEach(function(element,index){ element.setIcon(markerIcon); })
+                exposureGroups[key].markers.forEach(function (element, index) {
+                    element.setIcon(markerIcon);
+                })
             }
         }
 
-        function zoomToExtent(mapBounds){
-            if(mapBounds === undefined || mapBounds === null)
-            {
-                if(exposurePoints !== undefined && exposurePoints !== null){
+        function zoomToExtent(mapBounds) {
+            // Zoom to the extent of the selection or the extent of all points
+
+            if (mapBounds === undefined || mapBounds === null) {
+                if (IsValid(selectedGroupID))
+                    return zoomToGroup(selectedGroupID);
+                else if (selectedArea)
+                    return zoomToArea();
+                else if (IsValid(exposurePoints)) {
                     mapBounds = new google.maps.LatLngBounds();
-                    exposurePoints.forEach(function(element,index){
-                        if(element.getMap() !== null){
+                    exposurePoints.forEach(function (element, index) {
+                        if (element.getMap() !== null) {
                             mapBounds.extend(element.getPosition());
                         }
                     });
                 }
             }
+            map.setCenter(mapBounds.getCenter());
+            map.fitBounds(mapBounds);
+        }
+
+        function zoomToArea() {
+            // TODO: Should we zoom to the extent of the points within the
+            //       area instead of the area itself?
+            let areaBounds = selectedArea.getBounds();
+            map.setCenter(areaBounds.getCenter());
+            map.fitBounds(areaBounds);
+        }
+
+        function zoomToGroup(groupId) {
+            // Zoom to the extents of the group
+            mapBounds = new google.maps.LatLngBounds();
+
+            exposureGroups[groupId].markers.forEach(function (element, index) {
+                if (element.getMap() !== null) {
+                    mapBounds.extend(element.getPosition());
+                }
+            });
+
             map.setCenter(mapBounds.getCenter());
             map.fitBounds(mapBounds);
         }
@@ -553,21 +775,21 @@
         }
 
         function removeLine(polyline) {
-            if (polyline !== undefined && polyline !== null) {
+            if (IsValid(polyline)) {
                 polyline.setMap(null);
             }
         }
 
-        function erasePoint(event)
-        {
-            if(selectedMarker !== undefined && selectedMarker !== null)
-            {
+        function erasePoint(event) {
+            if (IsValid(selectedMarker)) {
                 editExposure(event, selectedMarker);
             }
         }
 
-        function eraseGroup(event, groupId){
-            exposureGroups[groupId].markers.forEach(function(element,index){ editExposure(event, element) });
+        function eraseGroup(event, groupId) {
+            exposureGroups[groupId].markers.forEach(function (element, index) {
+                editExposure(event, element)
+            });
         }
 
         function editExposure(event, marker) {
@@ -581,8 +803,9 @@
                     deleteExposure(i, marker);
                 }
             }
-            while (!bFoundPath && ++i < exposurePoints.length)
+            while (!bFoundPath && ++i < exposurePoints.length);
 
+            enableDelete(false, false);
         }
 
         function deleteExposure(i, marker) {
@@ -607,13 +830,31 @@
         }
 
         function saveText() {
-            let text = JSON.stringify(exposureJSON);
+            // Create the export format.  It should be exactly the same as
+            // the import format, just missing the redacted points.
+            let out = [];
+            for (var i = 0; i < exposureJSON.length; i++) {
+                if (exposureJSON[i].latitude && exposureJSON[i].longitude) {
+                    element = {};
+                    element.time = exposureJSON[i].time;
+                    element.longitude = exposureJSON[i].longitude;
+                    element.latitude = exposureJSON[i].latitude;
+                    out.push(element);
+                }
+            }
+
+            let text = JSON.stringify(out);
             let file = $("#privatekitJSON").get(0).files[0];
             let filename = file.name.replace(fileRegExp, "-REDACTED.json");
+
             var a = document.createElement('a');
             a.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
             a.setAttribute('download', filename);
             a.click();
+
+            // TODO: Use HTML5 saveAs()
+            //var blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+            //saveAs(blob, filename);
         }
     </script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>


### PR DESCRIPTION
This contains a basic user interface that can do:

* Zoom
* Select (directly or by area)
* Delete individual
* Delete group
* Save

The output file is now exactly the same as the input file format.

 ### Testing Notes ###
Load the sample data (e.g. "Sample_PrivateKit.json").  Zoom, redact, save.

Output should be in the exact same file format as the input, just redacted.

 ### Fixed Issues ###
Output was in a different format, had "null" values and extra properties.